### PR TITLE
Plugin to facilitate the creation of ADR document in markdown format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "java-spring-aws-dynamodb-plugin"]
 	path = java-spring-aws-dynamodb-plugin
 	url = https://github.com/zup-academy/java-spring-aws-dynamodb-plugin
+[submodule "stk-adr-app-doc-plugin"]
+	path = stk-adr-app-doc-plugin
+	url = https://github.com/deusemarjunior/stk-adr-app-doc-plugin.git


### PR DESCRIPTION
The plugin works by creating a directory at the root of the project in the path docs/adr, it allows you to choose between two templates, Michael Nygard or Log4brains

https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

https://github.com/thomvaill/log4brains

I would like to receive your feedback, if possible add the plugin so that I can receive more feedback

Thanks